### PR TITLE
fix puma gem:  invalid option: --daemon

### DIFF
--- a/lib/capistrano/tasks/daemon.rake
+++ b/lib/capistrano/tasks/daemon.rake
@@ -10,7 +10,7 @@ namespace :puma do
         else
           within current_path do
             with rack_env: fetch(:puma_env) do
-              execute :puma, "-C #{fetch(:puma_conf)} --daemon"
+              execute :puma, "-C #{fetch(:puma_conf)}"
             end
           end
         end


### PR DESCRIPTION
```
bundler: failed to load command: puma (/home/poter/apps/poter-api/shared/bundle/ruby/2.6.0/bin/puma)
Traceback (most recent call last):
	19: from /home/poter/.rbenv/versions/2.6.5/bin/bundle:23:in `<main>'
	18: from /home/poter/.rbenv/versions/2.6.5/bin/bundle:23:in `load'
	17: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/exe/bundle:37:in `<top (required)>'
	16: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
	15: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/exe/bundle:49:in `block in <top (required)>'
	14: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/cli.rb:24:in `start'
	13: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	12: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/cli.rb:30:in `dispatch'
	11: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	10: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	 9: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	 8: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/cli.rb:494:in `exec'
	 7: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/cli/exec.rb:28:in `run'
	 6: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/cli/exec.rb:63:in `kernel_load'
	 5: from /home/poter/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.2.15/lib/bundler/cli/exec.rb:63:in `load'
	 4: from /home/poter/apps/poter-api/shared/bundle/ruby/2.6.0/bin/puma:23:in `<top (required)>'
	 3: from /home/poter/apps/poter-api/shared/bundle/ruby/2.6.0/bin/puma:23:in `load'
	 2: from /home/poter/apps/poter-api/shared/bundle/ruby/2.6.0/gems/puma-5.2.2/bin/puma:8:in `<top (required)>'
	 1: from /home/poter/apps/poter-api/shared/bundle/ruby/2.6.0/gems/puma-5.2.2/bin/puma:8:in `new'
/home/poter/apps/poter-api/shared/bundle/ruby/2.6.0/gems/puma-5.2.2/lib/puma/cli.rb:50:in `initialize': invalid option: --daemon (OptionParser::InvalidOption)
```